### PR TITLE
Add support for puppet-lint 2.x

### DIFF
--- a/lib/puppet-lint/security.rb
+++ b/lib/puppet-lint/security.rb
@@ -2,7 +2,7 @@
 class PuppetLint::CheckPlugin
 
   # This types represent valid values for variables and parameters
-  VALID_CONTENT_TOKENS=[:NAME,:SSTRING,:STRING,:NUMBER,:TRUE,:FALSE,:DQPRE,:DQMID,:DQPOST,:VARIABLE]
+  VALID_CONTENT_TOKENS=[:NAME,:FUNCTION_NAME,:SSTRING,:STRING,:NUMBER,:TRUE,:FALSE,:DQPRE,:DQMID,:DQPOST,:VARIABLE]
 
   # Checks if given resource is defined in given class or define
   #
@@ -120,7 +120,7 @@ class PuppetLint::CheckPlugin
   def get_argument_token_for_function(tokens,function)
     lparen=tokens.find do |token|
       token.type == :LPAREN and
-        token.prev_code_token.type == :NAME and
+        token.prev_code_token.type == :FUNCTION_NAME and
         token.prev_code_token.value == function
     end
 
@@ -159,7 +159,7 @@ class PuppetLint::CheckPlugin
       t = block_starter.next_token
 
       until [:SEMIC,:RBRACE].include? t.type
-        token_array << t unless t.type == :COLON
+        token_array << t
         t = t.next_token
       end
 

--- a/puppet-lint-security-plugins.gemspec
+++ b/puppet-lint-security-plugins.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     Checks puppet manifests for security related problems.
   EOF
 
-  spec.add_dependency             'puppet-lint', '~> 1.0'
+  spec.add_dependency             'puppet-lint', '~> 2.0'
   spec.add_development_dependency 'rspec', '~> 3.3'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'

--- a/spec/puppet-lint/plugins/check_security_apache_no_ssl_vhost_spec.rb
+++ b/spec/puppet-lint/plugins/check_security_apache_no_ssl_vhost_spec.rb
@@ -16,7 +16,7 @@ apache::vhost { 'fourth.example.com':
       end
 
       it 'should create a warning' do
-        expect(problems).to contain_warning(msg).on_line(2).in_column(38)
+        expect(problems).to contain_warning(msg).on_line(2).in_column(37)
       end
     end
 

--- a/spec/puppet-lint/plugins/check_security_apt_absent_no_key_spec.rb
+++ b/spec/puppet-lint/plugins/check_security_apt_absent_no_key_spec.rb
@@ -24,7 +24,7 @@ apt::source {
       end
 
       it 'should create a error' do
-        expect(problems).to contain_error(msg).on_line(6).in_column(16)
+        expect(problems).to contain_error(msg).on_line(6).in_column(15)
       end
     end
 

--- a/spec/puppet-lint/plugins/check_security_apt_no_key_spec.rb
+++ b/spec/puppet-lint/plugins/check_security_apt_no_key_spec.rb
@@ -5,7 +5,8 @@ describe 'security_apt_no_key' do
 
   context 'with fix disabled' do
     context 'code having no key parameter in apt' do
-      let(:code) { "apt::source { 'puppetlabs':
+      let(:code) { "
+apt::source { 'puppetlabs':
   location => 'http://apt.puppetlabs.com',
   repos    => 'main',
 }
@@ -16,7 +17,7 @@ describe 'security_apt_no_key' do
       end
 
       it 'should create a error' do
-        expect(problems).to contain_error(msg).on_line(1).in_column(28)
+        expect(problems).to contain_error(msg).on_line(2).in_column(27)
       end
     end
 

--- a/spec/puppet-lint/plugins/check_security_firewall_any_any_deny_spec.rb
+++ b/spec/puppet-lint/plugins/check_security_firewall_any_any_deny_spec.rb
@@ -18,7 +18,7 @@ describe 'security_firewall_any_any_deny' do
       end
 
       it 'should create a warning' do
-        expect(problems).to contain_warning(msg).on_line(2).in_column(29)
+        expect(problems).to contain_warning(msg).on_line(2).in_column(28)
       end
     end
 
@@ -36,7 +36,7 @@ describe 'security_firewall_any_any_deny' do
       end
 
       it 'should create a warning' do
-        expect(problems).to contain_warning(msg).on_line(2).in_column(29)
+        expect(problems).to contain_warning(msg).on_line(2).in_column(28)
       end
     end
 
@@ -52,7 +52,7 @@ describe 'security_firewall_any_any_deny' do
       end
 
       it 'should create a warning' do
-        expect(problems).to contain_warning(msg).on_line(2).in_column(29)
+        expect(problems).to contain_warning(msg).on_line(2).in_column(28)
       end
     end
 
@@ -69,7 +69,7 @@ describe 'security_firewall_any_any_deny' do
       end
 
       it 'should create a warning' do
-        expect(problems).to contain_warning(msg).on_line(2).in_column(29)
+        expect(problems).to contain_warning(msg).on_line(2).in_column(28)
       end
     end
 
@@ -86,7 +86,7 @@ describe 'security_firewall_any_any_deny' do
       end
 
       it 'should create a warning' do
-        expect(problems).to contain_warning(msg).on_line(2).in_column(29)
+        expect(problems).to contain_warning(msg).on_line(2).in_column(28)
       end
     end
 
@@ -103,7 +103,7 @@ describe 'security_firewall_any_any_deny' do
       end
 
       it 'should create a warning' do
-        expect(problems).to contain_warning(msg).on_line(2).in_column(29)
+        expect(problems).to contain_warning(msg).on_line(2).in_column(28)
       end
     end
 

--- a/spec/puppet-lint/plugins/check_security_firewall_puppetmaster_any_deny_spec.rb
+++ b/spec/puppet-lint/plugins/check_security_firewall_puppetmaster_any_deny_spec.rb
@@ -18,7 +18,7 @@ describe 'security_firewall_puppetmaster_any_deny' do
       end
 
       it 'should create a warning' do
-        expect(problems).to contain_warning(msg).on_line(2).in_column(38)
+        expect(problems).to contain_warning(msg).on_line(2).in_column(37)
       end
     end
 
@@ -37,7 +37,7 @@ describe 'security_firewall_puppetmaster_any_deny' do
       end
 
       it 'should create a warning' do
-        expect(problems).to contain_warning(msg).on_line(2).in_column(38)
+        expect(problems).to contain_warning(msg).on_line(2).in_column(37)
       end
     end
 

--- a/spec/puppet-lint/plugins/check_security_tidy_all_files_spec.rb
+++ b/spec/puppet-lint/plugins/check_security_tidy_all_files_spec.rb
@@ -15,7 +15,7 @@ tidy { '/usr/local':
       end
 
       it 'should create a warning' do
-        expect(problems).to contain_warning(msg).on_line(2).in_column(21)
+        expect(problems).to contain_warning(msg).on_line(2).in_column(20)
       end
     end
 

--- a/spec/puppet-lint/plugins/check_security_user_with_id_0_created_spec.rb
+++ b/spec/puppet-lint/plugins/check_security_user_with_id_0_created_spec.rb
@@ -23,7 +23,7 @@ user {'myroot':
       end
 
       it 'should create a error' do
-        expect(problems).to contain_error(msg).on_line(3).in_column(16)
+        expect(problems).to contain_error(msg).on_line(3).in_column(15)
       end
     end
 


### PR DESCRIPTION
⚠️ **These changes are not compatible with puppet-lint 1.x**

- Function names now have their own token :FUNCTION_NAME
- Resource tokens now start with a :COLON token not a :NEW_LINE token
  (https://github.com/rodjek/puppet-lint/commit/67123e44773c7438cf2fbc9f33ad0e5bd2570d9e#diff-a10628dd333356a3c7834f4972961f06)
  - Update title_tokens_with_block to account for this change
  - Update specs to check for correct column number in errors